### PR TITLE
Rework to use the ElementModel and the R5 fhirpath engine always

### DIFF
--- a/src/main/java/com/fhirpathlab/ContextFactory.java
+++ b/src/main/java/com/fhirpathlab/ContextFactory.java
@@ -25,8 +25,10 @@ public class ContextFactory {
   }
 
   private org.hl7.fhir.r4b.context.SimpleWorkerContext contextR4b;
+  private org.hl7.fhir.r5.context.SimpleWorkerContext contextR4basR5;
   private org.hl7.fhir.r5.context.SimpleWorkerContext contextR5;
   private NpmPackage r4NpmPackage;
+  private NpmPackage r5NpmPackage;
 
   private NpmPackage getNpmPackageR4() throws FHIRException, IOException {
     if (r4NpmPackage == null) {
@@ -35,6 +37,15 @@ public class ContextFactory {
       r4NpmPackage = pkgMgr.loadPackage("hl7.fhir.r4b.core", "4.3.0");
     }
     return r4NpmPackage;
+  }
+
+  private NpmPackage getNpmPackageR5() throws FHIRException, IOException {
+    if (r5NpmPackage == null) {
+      var pkgMgr = new FilesystemPackageCacheManager.Builder().build();
+      pkgMgr.setMinimalMemory(true);
+      r5NpmPackage = pkgMgr.loadPackage("hl7.fhir.r5.core", "5.0.0");
+    }
+    return r5NpmPackage;
   }
 
   public org.hl7.fhir.r4b.context.SimpleWorkerContext getContextR4b() throws FHIRException, IOException {
@@ -50,11 +61,24 @@ public class ContextFactory {
     return contextR4b;
   }
 
+  public org.hl7.fhir.r5.context.SimpleWorkerContext getContextR4bAsR5() throws FHIRException, IOException {
+    if (contextR4basR5 == null) {
+      var context = new FhirpathLabSimpleWorkerContextR5();
+      context.setProgress(true);
+      var pkg = getNpmPackageR4();
+      context.loadFromPackage(pkg, new R5ContextLoader());
+      context.unloadBinaries();
+      contextR4basR5 = context;
+      r4NpmPackage = null; // release the memory
+    }
+    return contextR4basR5;
+  }
+
   public org.hl7.fhir.r5.context.SimpleWorkerContext getContextR5() throws FHIRException, IOException {
     if (contextR5 == null) {
       var context = new FhirpathLabSimpleWorkerContextR5();
       context.setProgress(true);
-      var pkg = getNpmPackageR4();
+      var pkg = getNpmPackageR5();
       context.loadFromPackage(pkg, new R5ContextLoader());
       context.unloadBinaries();
       contextR5 = context;

--- a/src/main/java/com/fhirpathlab/FHIRPathTestEvaluationServicesR5.java
+++ b/src/main/java/com/fhirpathlab/FHIRPathTestEvaluationServicesR5.java
@@ -3,57 +3,67 @@ package com.fhirpathlab;
 import java.util.List;
 import java.util.HashMap;
 
-import org.hl7.fhir.r4b.fhirpath.FHIRPathEngine;
-import org.hl7.fhir.r4b.fhirpath.FHIRPathEngine.IEvaluationContext;
-import org.hl7.fhir.r4b.fhirpath.FHIRPathUtilityClasses.FunctionDetails;
-import org.hl7.fhir.r4b.fhirpath.TypeDetails;
-import org.hl7.fhir.r4b.fhirpath.ExpressionNode.CollectionStatus;
-import org.hl7.fhir.r4b.model.Base;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine.IEvaluationContext;
+import org.hl7.fhir.r5.fhirpath.FHIRPathUtilityClasses.FunctionDetails;
+import org.hl7.fhir.r5.fhirpath.TypeDetails;
+import org.hl7.fhir.r5.fhirpath.ExpressionNode.CollectionStatus;
+import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r4b.model.Parameters;
-import org.hl7.fhir.r4b.model.StringType;
-import org.hl7.fhir.r4b.model.ValueSet;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r5.model.ValueSet;
 
 import com.fhirpathlab.utils.ParamUtils;
 
-import org.hl7.fhir.r4b.elementmodel.ObjectConverter;
-import org.hl7.fhir.r4b.context.IWorkerContext;
+import org.hl7.fhir.r5.elementmodel.ObjectConverter;
+import org.hl7.fhir.r5.context.IWorkerContext;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.exceptions.PathEngineException;
 
-public class FHIRPathTestEvaluationServices implements IEvaluationContext {
+public class FHIRPathTestEvaluationServicesR5 implements IEvaluationContext {
     private Parameters.ParametersParameterComponent traceToParameter;
-    private java.util.HashMap<String, org.hl7.fhir.r4b.model.Base> mapVariables;
+    private java.util.HashMap<String, org.hl7.fhir.r5.model.Base> mapVariables;
     IWorkerContext context;
     ObjectConverter oc;
 
-    public FHIRPathTestEvaluationServices(IWorkerContext context) {
+    public FHIRPathTestEvaluationServicesR5(IWorkerContext context) {
         this.context = context;
         oc = new ObjectConverter(context);
         mapVariables = new HashMap<>();
+    }
+
+    public IWorkerContext getContext() {
+        return context;
     }
 
     public void setTraceToParameter(Parameters.ParametersParameterComponent theTraceToParameter) {
         traceToParameter = theTraceToParameter;
     }
 
-    public void addVariable(String name, org.hl7.fhir.r4b.model.Base value) {
+    public void addVariable(String name, org.hl7.fhir.r5.model.Base value) {
         mapVariables.put(name, value);
     }
 
-    public java.util.Map<String, org.hl7.fhir.r4b.model.Base> getVariables() {
+    public void addVariable(String name, org.hl7.fhir.r4b.model.Base value) {
+        // convert the object to R5 object models
+
+        // mapVariables.put(name, value);
+    }
+
+    public java.util.Map<String, org.hl7.fhir.r5.model.Base> getVariables() {
         return mapVariables;
     }
 
     @Override
-    public List<org.hl7.fhir.r4b.model.Base> resolveConstant(FHIRPathEngine engine, Object appContext, String name,
+    public List<org.hl7.fhir.r5.model.Base> resolveConstant(FHIRPathEngine engine, Object appContext, String name,
             boolean beforeContext, boolean explicitConstant)
             throws PathEngineException {
         if (mapVariables != null) {
             if (mapVariables.containsKey(name)) {
-                var result = new java.util.ArrayList<org.hl7.fhir.r4b.model.Base>();
-                org.hl7.fhir.r4b.model.Base itemValue = mapVariables.get(name);
+                var result = new java.util.ArrayList<org.hl7.fhir.r5.model.Base>();
+                org.hl7.fhir.r5.model.Base itemValue = mapVariables.get(name);
                 if (itemValue != null)
                     result.add(itemValue);
                 return result;
@@ -66,26 +76,18 @@ public class FHIRPathTestEvaluationServices implements IEvaluationContext {
     }
 
     @Override
-    public boolean log(String argument, List<org.hl7.fhir.r4b.model.Base> data) {
+    public boolean log(String argument, List<org.hl7.fhir.r5.model.Base> data) {
         if (traceToParameter != null) {
             Parameters.ParametersParameterComponent traceValue = ParamUtils.add(traceToParameter, "trace",
-                    new StringType(argument));
+                    new org.hl7.fhir.r4b.model.StringType(argument));
 
-            for (org.hl7.fhir.r4b.model.Base nextOutput : data) {
-                if (nextOutput instanceof org.hl7.fhir.r4b.elementmodel.Element) {
-                    var em = (org.hl7.fhir.r4b.elementmodel.Element) nextOutput;
-                    // ParamUtils.addTypedElement(context, oc, traceValue, em);
-                } else if (nextOutput instanceof org.hl7.fhir.r4b.model.DataType) {
-                    var dt = (org.hl7.fhir.r4b.model.DataType) nextOutput;
-                    if (dt instanceof StringType) {
-                        StringType st = (StringType) dt;
-                        if (st.getValue().equalsIgnoreCase(""))
-                            ParamUtils.add(traceValue, "empty-string");
-                        else
-                            ParamUtils.add(traceValue, dt.fhirType(), st);
-                    } else {
-                        ParamUtils.add(traceValue, dt.fhirType(), dt);
-                    }
+            for (org.hl7.fhir.r5.model.Base nextOutput : data) {
+                if (nextOutput instanceof org.hl7.fhir.r5.elementmodel.Element) {
+                    var em = (org.hl7.fhir.r5.elementmodel.Element) nextOutput;
+                    ParamUtils.addTypedElement(context, oc, traceValue, em);
+                } else if (nextOutput instanceof org.hl7.fhir.r5.model.DataType) {
+                    var dt = (org.hl7.fhir.r5.model.DataType) nextOutput;
+                    ParamUtils.add(traceValue, dt.fhirType(), dt);
                 }
             }
             return true;
@@ -100,7 +102,7 @@ public class FHIRPathTestEvaluationServices implements IEvaluationContext {
         if (mapVariables != null) {
             var key = name.substring(1);
             if (mapVariables.containsKey(key)) {
-                org.hl7.fhir.r4b.model.Base itemValue = mapVariables.get(key);
+                org.hl7.fhir.r5.model.Base itemValue = mapVariables.get(key);
                 if (itemValue != null)
                     return new TypeDetails(CollectionStatus.SINGLETON, itemValue.fhirType());
             }
@@ -144,5 +146,11 @@ public class FHIRPathTestEvaluationServices implements IEvaluationContext {
     @Override
     public ValueSet resolveValueSet(FHIRPathEngine engine, Object appContext, String url) {
         throw new UnsupportedOperationException("Unimplemented method 'resolveValueSet'");
+    }
+
+    @Override
+    public boolean paramIsType(String name, int index) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'paramIsType'");
     }
 }

--- a/src/main/java/com/fhirpathlab/FhirpathLabSimpleWorkerContextR5.java
+++ b/src/main/java/com/fhirpathlab/FhirpathLabSimpleWorkerContextR5.java
@@ -1,14 +1,30 @@
 package com.fhirpathlab;
 
 import java.io.IOException;
+import java.util.List;
+
+import org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.utilities.validation.ValidationMessage.IssueSeverity;
 
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.CodeableConcept;
+import org.hl7.fhir.r5.model.Coding;
 import org.hl7.fhir.r5.model.Resource;
+import org.hl7.fhir.r5.model.ValueSet;
+import org.hl7.fhir.r5.terminologies.utilities.ValidationResult;
+import org.hl7.fhir.r5.utils.validation.ValidationContextCarrier;
+import org.hl7.fhir.utilities.validation.ValidationOptions;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FhirpathLabSimpleWorkerContextR5 extends org.hl7.fhir.r5.context.SimpleWorkerContext {
 
+  public FhirpathLabSimpleWorkerContextR5(org.hl7.fhir.r5.context.SimpleWorkerContext other) throws IOException, FHIRException {
+    super(other);
+  }
+
+  @Autowired
   public FhirpathLabSimpleWorkerContextR5() throws IOException, FHIRException {
     super(new SimpleWorkerContextBuilder().fromNothing());
   }
@@ -23,5 +39,49 @@ public class FhirpathLabSimpleWorkerContextR5 extends org.hl7.fhir.r5.context.Si
     if (r != null)
       return r;
     return null;
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions options, Coding code, ValueSet vs) {
+    return super.validateCode(options, code, vs);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions arg0, CodeableConcept arg1, ValueSet arg2) {
+    return super.validateCode(arg0, arg1, arg2);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions options, String code, ValueSet vs) {
+      return super.validateCode(options, code, vs);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions optionsArg, Coding code, ValueSet vs,
+          ValidationContextCarrier ctxt) {
+      return super.validateCode(optionsArg, code, vs, ctxt);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions options, String system, String version, String code,
+          String display) {
+      List<OperationOutcomeIssueComponent> issues = new java.util.ArrayList<>();
+      return new ValidationResult(IssueSeverity.INFORMATION, "Not validating in the Mapper", issues);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions options, String system, String version, String code,
+          String display, ValueSet vs) {
+      return super.validateCode(options, system, version, code, display, vs);
+  }
+
+  @Override
+  public ValidationResult validateCode(ValidationOptions options, String path, Coding code, ValueSet vs) {
+    return super.validateCode(options, path, code, vs);
+  }
+  @Override
+  public ValidationResult validateCode(ValidationOptions arg0, String arg1, Coding arg2, ValueSet arg3,
+      ValidationContextCarrier arg4) {
+    return super.validateCode(arg0, arg1, arg2, arg3, arg4);
   }
 }

--- a/src/main/java/com/fhirpathlab/FhirpathTestController.java
+++ b/src/main/java/com/fhirpathlab/FhirpathTestController.java
@@ -116,7 +116,7 @@ public class FhirpathTestController {
                 if (parametersR5.getParameter("resource") != null)
                     resource = getResourceR5(contextFactory.getContextR5(), parametersR5.getParameter("resource"));
 
-                var responseParameters = evaluate(contextFactory.getContextR5(), resource, contextExpression, expression, variables);
+                var responseParameters = evaluate("R5", contextFactory.getContextR5(), resource, contextExpression, expression, variables);
                 return new ResponseEntity<>(parser.composeString(responseParameters), HttpStatus.OK);
             }
 
@@ -201,7 +201,7 @@ public class FhirpathTestController {
                 if (parameters.getParameter("resource") != null)
                     resource = getResource(contextFactory.getContextR4bAsR5(), parameters.getParameter("resource"));
 
-                var responseParameters = evaluate(contextFactory.getContextR4bAsR5(), resource, contextExpression, expression, variables);
+                var responseParameters = evaluate("R4B", contextFactory.getContextR4bAsR5(), resource, contextExpression, expression, variables);
                 return new ResponseEntity<>(parser.composeString(responseParameters), HttpStatus.OK);
             }
 
@@ -453,13 +453,13 @@ public class FhirpathTestController {
         return contextOutputs;
     }
 
-    public Parameters evaluate(org.hl7.fhir.r5.context.SimpleWorkerContext context, org.hl7.fhir.r5.elementmodel.Element resource, String contextExpression,
+    public Parameters evaluate(String testEngineVersion, org.hl7.fhir.r5.context.SimpleWorkerContext context, org.hl7.fhir.r5.elementmodel.Element resource, String contextExpression,
             String expression,
             Parameters.ParametersParameterComponent variables) throws IOException {
         var responseParameters = new Parameters();
         responseParameters.setId("fhirpath");
         var paramsPart = ParamUtils.add(responseParameters, "parameters");
-        ParamUtils.add(paramsPart, "evaluator", "Java 6.5.19 (r4b)");
+        ParamUtils.add(paramsPart, "evaluator", "Java 6.5.19 ("+testEngineVersion+")");
         ParamUtils.add(paramsPart, "context", contextExpression);
         ParamUtils.add(paramsPart, "expression", expression);
 

--- a/src/main/java/com/fhirpathlab/FhirpathTestController.java
+++ b/src/main/java/com/fhirpathlab/FhirpathTestController.java
@@ -189,7 +189,17 @@ public class FhirpathTestController {
             }
 
             // Parse the input content into a Patient resource
-            var parameters = (org.hl7.fhir.r4b.model.Parameters) parser.parse(content);
+            org.hl7.fhir.r4b.model.Parameters parameters = null;
+            try {
+                parameters = (org.hl7.fhir.r4b.model.Parameters) parser.parse(content);
+            } catch (IOException e) {
+                logger.error("Error parsing resource: " + e.getMessage(), e);
+                outcome.addIssue().setSeverity(org.hl7.fhir.r4b.model.OperationOutcome.IssueSeverity.ERROR)
+                        .setCode(org.hl7.fhir.r4b.model.OperationOutcome.IssueType.EXCEPTION)
+                        .setDetails(new CodeableConcept().setText(e.getMessage()));
+                return new ResponseEntity<>(parser.composeString(outcome), HttpStatus.BAD_REQUEST);
+            }
+
             String contextExpression = null;
             if (parameters.getParameterValue("context") != null)
                 contextExpression = parameters.getParameterValue("context").primitiveValue();

--- a/src/main/java/com/fhirpathlab/FhirpathTestController.java
+++ b/src/main/java/com/fhirpathlab/FhirpathTestController.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fhirpathlab.utils.AstMapper;
 import com.fhirpathlab.utils.JsonNode;
+import com.fhirpathlab.utils.LogicalModelBuilder;
 import com.fhirpathlab.utils.ParamUtils;
 import com.fhirpathlab.utils.SimplifiedExpressionNode;
 
@@ -22,16 +23,17 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.hl7.fhir.r4b.elementmodel.Manager;
-import org.hl7.fhir.r4b.model.Base;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.model.Base;
 import org.hl7.fhir.r4b.model.CodeableConcept;
 import org.hl7.fhir.r4b.model.Parameters;
 import org.hl7.fhir.r4b.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.r4b.model.StringType;
-import org.hl7.fhir.r4b.elementmodel.Manager.FhirFormat;
-import org.hl7.fhir.r4b.fhirpath.ExpressionNode;
-import org.hl7.fhir.r4b.fhirpath.FHIRLexer.FHIRLexerException;
-import org.hl7.fhir.r4b.fhirpath.FHIRPathEngine;
+import org.hl7.fhir.r5.elementmodel.ValidatedFragment;
+import org.hl7.fhir.r5.fhirpath.ExpressionNode;
+import org.hl7.fhir.r5.fhirpath.FHIRLexer.FHIRLexerException;
+import org.hl7.fhir.r5.fhirpath.FHIRPathEngine;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -46,7 +48,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @RestController
-@RequestMapping("/fhir")
+@RequestMapping({ "/fhir", "/fhir5" })
 @CrossOrigin(origins = "*", // Replace with your client origin
         methods = { RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT }, allowedHeaders = { "Content-Type",
                 "Accept", "Origin", "cache-control" }, exposedHeaders = { "Location", "Content-Location" })
@@ -56,11 +58,103 @@ public class FhirpathTestController {
     private static final Logger logger = LoggerFactory.getLogger(FhirpathTestController.class);
     private org.hl7.fhir.r4b.formats.XmlParser xmlParser;
     private org.hl7.fhir.r4b.formats.JsonParser jsonParser;
+    private org.hl7.fhir.r5.formats.JsonParser jsonParserR5;
 
     public FhirpathTestController(ContextFactory contextFactory) {
         this.contextFactory = contextFactory;
         xmlParser = new org.hl7.fhir.r4b.formats.XmlParser();
         jsonParser = new org.hl7.fhir.r4b.formats.JsonParser();
+        jsonParserR5 = new org.hl7.fhir.r5.formats.JsonParser();
+    }
+
+    /**
+     * Handles PUT requests for FHIR Patient resources.
+     *
+     * This method parses the incoming content based on its type (JSON or XML),
+     * converts it to a FHIR Patient object, and performs necessary operations.
+     *
+     * @param content     The string content of the FHIR Patient resource.
+     * @param contentType The MIME type of the content.
+     * @return A confirmation message with the patient ID or an error message.
+     * @throws Exception if the content cannot be parsed correctly.
+     */
+    @PostMapping(value = "/$fhirpath-r5", consumes = { MediaType.APPLICATION_JSON_VALUE,
+            MediaType.APPLICATION_XML_VALUE,
+            "application/fhir+json;fhirVersion=4.0" })
+    public ResponseEntity<String> evaluateFhirPathR5(@RequestBody String content,
+            @RequestHeader(HttpHeaders.CONTENT_TYPE) String contentType) {
+        var outcome = new org.hl7.fhir.r4b.model.OperationOutcome();
+        org.hl7.fhir.r4b.formats.IParser parser = null;
+        org.hl7.fhir.r5.formats.IParser parserR5 = null;
+
+        logger.info("Evaluating: fhir5/$fhirpath-r5");
+        try {
+            // Determine the appropriate parser based on Content-Type header
+            if (contentType != null && contentType.contains(MediaType.APPLICATION_XML_VALUE)) {
+                parser = xmlParser;
+                parserR5 = new org.hl7.fhir.r5.formats.XmlParser();
+                parser.setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY);
+            } else {
+                parser = jsonParser; // Default to JSON parser
+                parserR5 = new org.hl7.fhir.r5.formats.JsonParser();
+                parser.setOutputStyle(org.hl7.fhir.r4b.formats.IParser.OutputStyle.PRETTY);
+            }
+
+            // Parse the input content into a Patient resource
+            var parameters = (org.hl7.fhir.r4b.model.Parameters) parser.parse(content);
+            var parametersR5 = (org.hl7.fhir.r5.model.Parameters) parserR5.parse(content);  
+            String contextExpression = null;
+            if (parameters.getParameterValue("context") != null)
+                contextExpression = parameters.getParameterValue("context").primitiveValue();
+            String expression = null;
+            if (parameters.getParameterValue("expression") != null)
+                expression = parameters.getParameterValue("expression").primitiveValue();
+            Parameters.ParametersParameterComponent variables = parameters.getParameter("variables");
+
+            if (isNotBlank(expression)) {
+                org.hl7.fhir.r5.elementmodel.Element resource = null;
+                if (parametersR5.getParameter("resource") != null)
+                    resource = getResourceR5(contextFactory.getContextR5(), parametersR5.getParameter("resource"));
+
+                var responseParameters = evaluate(contextFactory.getContextR5(), resource, contextExpression, expression, variables);
+                return new ResponseEntity<>(parser.composeString(responseParameters), HttpStatus.OK);
+            }
+
+            // There is no expression, so we should return that as an issue
+            logger.error("Cannot evaluate without a fhirpath expression");
+            outcome.addIssue().setSeverity(org.hl7.fhir.r4b.model.OperationOutcome.IssueSeverity.ERROR)
+                    .setCode(org.hl7.fhir.r4b.model.OperationOutcome.IssueType.INCOMPLETE)
+                    .setDetails(new CodeableConcept().setText("Cannot evaluate without a fhirpath expression"));
+
+            return new ResponseEntity<>(parser.composeString(outcome), HttpStatus.BAD_REQUEST);
+        } catch (org.hl7.fhir.exceptions.PathEngineException e) {
+            logger.error("Error processing $fhirpath", e);
+            var location = new java.util.ArrayList<StringType>();
+            if (e.getLocation() != null)
+                location.add(new StringType(e.getLocation().toString()));
+            outcome.addIssue().setSeverity(org.hl7.fhir.r4b.model.OperationOutcome.IssueSeverity.ERROR)
+                    .setCode(org.hl7.fhir.r4b.model.OperationOutcome.IssueType.EXCEPTION)
+                    .setLocation(location)
+                    .setDetails(new CodeableConcept().setText(e.getMessage()));
+        } catch (org.hl7.fhir.exceptions.FHIRException e) {
+            logger.error("Error processing $fhirpath", e);
+            outcome.addIssue().setSeverity(org.hl7.fhir.r4b.model.OperationOutcome.IssueSeverity.ERROR)
+                    .setCode(org.hl7.fhir.r4b.model.OperationOutcome.IssueType.EXCEPTION)
+                    .setDetails(new CodeableConcept().setText(e.getMessage()));
+        } catch (Exception e) {
+            logger.error("Error processing $fhirpath", e);
+            outcome.addIssue().setSeverity(org.hl7.fhir.r4b.model.OperationOutcome.IssueSeverity.ERROR)
+                    .setCode(org.hl7.fhir.r4b.model.OperationOutcome.IssueType.EXCEPTION)
+                    .setDetails(new CodeableConcept().setText("Unknown error evaluating fhirpath expression"))
+                    .setDiagnostics(e.getMessage());
+        }
+        try {
+            logger.error("Unknown Error processing $fhirpath : result in outcome");
+            return new ResponseEntity<>(parser.composeString(outcome), HttpStatus.BAD_REQUEST);
+        } catch (Exception ep) {
+            logger.error("Error reporting operationoutcome for $fhirpath result", ep);
+            return new ResponseEntity<>(ep.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**
@@ -103,11 +197,11 @@ public class FhirpathTestController {
             Parameters.ParametersParameterComponent variables = parameters.getParameter("variables");
 
             if (isNotBlank(expression)) {
-                org.hl7.fhir.r4b.model.Resource resource = null;
+                org.hl7.fhir.r5.elementmodel.Element resource = null;
                 if (parameters.getParameter("resource") != null)
-                    resource = parameters.getParameter("resource").getResource();
+                    resource = getResource(contextFactory.getContextR4bAsR5(), parameters.getParameter("resource"));
 
-                var responseParameters = evaluate(resource, contextExpression, expression, variables);
+                var responseParameters = evaluate(contextFactory.getContextR4bAsR5(), resource, contextExpression, expression, variables);
                 return new ResponseEntity<>(parser.composeString(responseParameters), HttpStatus.OK);
             }
 
@@ -148,22 +242,147 @@ public class FhirpathTestController {
         }
     }
 
-    private void processVariables(Parameters.ParametersParameterComponent variables,
+    private org.hl7.fhir.r5.elementmodel.Element getResource(org.hl7.fhir.r5.context.SimpleWorkerContext context, ParametersParameterComponent part) {
+        try {
+            if (part.getResource() != null) {
+                // convert the resource into an element (via a JASON string)
+                String jsonText = jsonParser.composeString(part.getResource());
+                InputStream inputStream = new ByteArrayInputStream(jsonText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.JSON);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+
+            // See if there is a json fragment extension
+            if (part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/json-value") != null) {
+                var jsonText = part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/json-value")
+                        .getValue().primitiveValue();
+                InputStream inputStream = new ByteArrayInputStream(jsonText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.JSON);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+            // See if there is a xml fragment extension
+            if (part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/xml-value") != null) {
+                var xmlText = part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/xml-value")
+                        .getValue().primitiveValue();
+                InputStream inputStream = new ByteArrayInputStream(xmlText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.XML);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+
+        } catch (IOException e) {
+            logger.error("Error converting resource to element model", e);
+        }
+        return null;
+    }
+
+    private org.hl7.fhir.r5.elementmodel.Element getResourceR5(org.hl7.fhir.r5.context.SimpleWorkerContext context, org.hl7.fhir.r5.model.Parameters.ParametersParameterComponent part) {
+        try {
+            if (part.getResource() != null) {
+                // convert the resource into an element (via a JSON string)
+                String jsonText = jsonParserR5.composeString(part.getResource());
+                InputStream inputStream = new ByteArrayInputStream(jsonText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.JSON);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+
+            // See if there is a json fragment extension
+            if (part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/json-value") != null) {
+                var jsonText = part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/json-value")
+                        .getValue().primitiveValue();
+                InputStream inputStream = new ByteArrayInputStream(jsonText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.JSON);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+            // See if there is a xml fragment extension
+            if (part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/xml-value") != null) {
+                var xmlText = part.getExtensionByUrl("http://fhir.forms-lab.com/StructureDefinition/xml-value")
+                        .getValue().primitiveValue();
+                InputStream inputStream = new ByteArrayInputStream(xmlText.getBytes(StandardCharsets.UTF_8));
+                var fragments = Manager.parse(context, inputStream,
+                        org.hl7.fhir.r5.elementmodel.Manager.FhirFormat.XML);
+                if (fragments.size() != 1) {
+                    throw new FHIRException("Unable to parse resource");
+                }
+                var element = fragments.get(0).getElement();
+                return element;
+            }
+
+        } catch (IOException e) {
+            logger.error("Error converting resource to element model", e);
+        }
+        return null;
+    }
+
+    private void processVariables(org.hl7.fhir.r5.context.SimpleWorkerContext context, Parameters.ParametersParameterComponent variables,
             ParametersParameterComponent paramsPart,
-            FHIRPathTestEvaluationServices services) {
+            FHIRPathTestEvaluationServicesR5 services) {
         if (variables != null && variables.getPart() != null && !variables.getPart().isEmpty()) {
             paramsPart.addPart(variables);
             var variableParts = variables.getPart();
             for (int i = 0; i < variableParts.size(); i++) {
                 var part = variableParts.get(i);
                 if (part.getResource() != null)
-                    services.addVariable(part.getName(), part.getResource());
+                    services.addVariable(part.getName(), getResource(context, part));
                 else {
                     if (part.getExtensionByUrl(
                             "http://fhir.forms-lab.com/StructureDefinition/json-value") != null) {
                         // this is not currently supported...
-                        services.addVariable(part.getName(), null);
+                        var variableText = part.getExtensionByUrl(
+                                "http://fhir.forms-lab.com/StructureDefinition/json-value").getValue().primitiveValue();
+                        var sd = LogicalModelBuilder.build(variableText, part.getName(), null);
+                        // services.context.cacheResource(sd);
+
+                        InputStream inputStream = new ByteArrayInputStream(
+                                variableText.getBytes(StandardCharsets.UTF_8));
+                        // This isn't a native FHIR resource, so use a generic parser (which may be able
+                        // to handle the logical models)
+                        List<ValidatedFragment> fragments;
+                        try {
+                            if (variableText.startsWith("{")) {
+                                var rawJsonParser = new org.hl7.fhir.r5.elementmodel.JsonParser(services.context);
+                                fragments = rawJsonParser.parse(inputStream);
+                            } else {
+                                var rawXmlParser = new org.hl7.fhir.r5.elementmodel.XmlParser(services.context);
+                                fragments = rawXmlParser.parse(inputStream);
+                            }
+                            if (fragments.size() == 1) {
+                                var sourceVariable = fragments.get(0).getElement();
+                                services.addVariable(part.getName(), sourceVariable);
+                            } else {
+                                throw new FHIRException("Unable to parse resource");
+                            }
+                        } catch (IOException e) {
+                            logger.error("Error parsing custom variable value", e);
+                        }
+
+                        // services.addVariable(part.getName(), null);
                     } else {
+
                         services.addVariable(part.getName(), part.getValue());
                     }
                 }
@@ -175,7 +394,7 @@ public class FhirpathTestController {
             ParametersParameterComponent paramsPart, FHIRPathEngine engine,
             org.hl7.fhir.r4b.model.OperationOutcome outcome) {
         try {
-            org.hl7.fhir.r4b.fhirpath.ExpressionNode parseTree;
+            org.hl7.fhir.r5.fhirpath.ExpressionNode parseTree;
             parseTree = engine.parse(expression);
 
             // Also check the expression tree so that it decudes any errrors, and marks up
@@ -186,7 +405,7 @@ public class FhirpathTestController {
                 if (!contextExpression.startsWith(resourceType))
                     contextExpression = resourceType + "." + contextExpression;
 
-                engine.check(null, resourceType, contextExpression, parseTree);
+                engine.check(null, resourceType, resourceType, contextExpression, parseTree);
             } catch (FHIRLexerException e) {
                 logger.error("Error parsing expression: ", e);
             } catch (org.hl7.fhir.exceptions.PathEngineException e) {
@@ -217,7 +436,7 @@ public class FhirpathTestController {
         }
     }
 
-    private List<Base> evaluateContexts(String contextExpression, org.hl7.fhir.r4b.elementmodel.Element sourceResource,
+    private List<Base> evaluateContexts(String contextExpression, org.hl7.fhir.r5.elementmodel.Element sourceResource,
             FHIRPathEngine engine) {
         List<Base> contextOutputs;
         if (contextExpression != null) {
@@ -234,7 +453,8 @@ public class FhirpathTestController {
         return contextOutputs;
     }
 
-    public Parameters evaluate(org.hl7.fhir.r4b.model.Resource resource, String contextExpression, String expression,
+    public Parameters evaluate(org.hl7.fhir.r5.context.SimpleWorkerContext context, org.hl7.fhir.r5.elementmodel.Element resource, String contextExpression,
+            String expression,
             Parameters.ParametersParameterComponent variables) throws IOException {
         var responseParameters = new Parameters();
         responseParameters.setId("fhirpath");
@@ -243,26 +463,17 @@ public class FhirpathTestController {
         ParamUtils.add(paramsPart, "context", contextExpression);
         ParamUtils.add(paramsPart, "expression", expression);
 
-        String resourceText = null;
-        if (resource != null) {
-            resourceText = jsonParser.composeString(resource);
-        }
-        InputStream inputStream = new ByteArrayInputStream(resourceText.getBytes(StandardCharsets.UTF_8));
-        org.hl7.fhir.r4b.elementmodel.Element sourceResource = null;
-        var context = contextFactory.getContextR4b();
-        sourceResource = Manager.parseSingle((context), inputStream, FhirFormat.JSON);
+        var engine = new org.hl7.fhir.r5.fhirpath.FHIRPathEngine(context);
 
-        var engine = new org.hl7.fhir.r4b.fhirpath.FHIRPathEngine(context);
-
-        FHIRPathTestEvaluationServices services = new FHIRPathTestEvaluationServices(context);
+        FHIRPathTestEvaluationServicesR5 services = new FHIRPathTestEvaluationServicesR5(context);
         engine.setHostServices(services);
 
         // pass through all the variables
-        processVariables(variables, paramsPart, services);
+        processVariables(context, variables, paramsPart, services);
 
         // Parse out the expression tree for the debug output
         var outcome = new org.hl7.fhir.r4b.model.OperationOutcome();
-        generateParseTree(resource.getResourceType().name(), contextExpression, expression, paramsPart, engine,
+        generateParseTree(resource.fhirType(), contextExpression, expression, paramsPart, engine,
                 outcome);
         if (outcome.hasIssue()) {
             var oucomePart = paramsPart.addPart();
@@ -271,27 +482,27 @@ public class FhirpathTestController {
         }
 
         // locate all of the context objects
-        List<Base> contextOutputs = evaluateContexts(contextExpression, sourceResource, engine);
+        List<Base> contextOutputs = evaluateContexts(contextExpression, resource, engine);
 
         processEvaluationResults(context, responseParameters, contextExpression, expression, engine, services,
-                sourceResource, contextOutputs);
+                resource, contextOutputs);
         return responseParameters;
     }
 
-    private void processEvaluationResults(org.hl7.fhir.r4b.context.IWorkerContext context,
+    private void processEvaluationResults(org.hl7.fhir.r5.context.IWorkerContext context,
             Parameters responseParameters, String contextExpression, String expression,
-            FHIRPathEngine engine, FHIRPathTestEvaluationServices services,
-            org.hl7.fhir.r4b.elementmodel.Element sourceResource, List<Base> contextOutputs) {
-        var oc = new org.hl7.fhir.r4b.elementmodel.ObjectConverter(context);
+            FHIRPathEngine engine, FHIRPathTestEvaluationServicesR5 services,
+            org.hl7.fhir.r5.elementmodel.Element sourceResource, List<Base> contextOutputs) {
+        var oc = new org.hl7.fhir.r5.elementmodel.ObjectConverter(context);
 
         for (int i = 0; i < contextOutputs.size(); i++) {
-            org.hl7.fhir.r4b.model.Base node = contextOutputs.get(i);
+            org.hl7.fhir.r5.model.Base node = contextOutputs.get(i);
             var resultPart = ParamUtils.add(responseParameters, "result");
             services.setTraceToParameter(resultPart);
             if (contextExpression != null)
                 resultPart.setValue(new StringType(String.format("%s[%d]", contextExpression, i)));
 
-            List<org.hl7.fhir.r4b.model.Base> outputs;
+            List<org.hl7.fhir.r5.model.Base> outputs;
             try {
                 ExpressionNode exp = engine.parse(expression);
                 outputs = engine.evaluate(null, sourceResource, sourceResource, node, exp);
@@ -301,20 +512,12 @@ public class FhirpathTestController {
             }
 
             for (Base nextOutput : outputs) {
-                if (nextOutput instanceof org.hl7.fhir.r4b.elementmodel.Element) {
-                    var em = (org.hl7.fhir.r4b.elementmodel.Element) nextOutput;
+                if (nextOutput instanceof org.hl7.fhir.r5.elementmodel.Element) {
+                    var em = (org.hl7.fhir.r5.elementmodel.Element) nextOutput;
                     ParamUtils.addTypedElement(context, oc, resultPart, em);
-                } else if (nextOutput instanceof org.hl7.fhir.r4b.model.DataType) {
-                    var dt = (org.hl7.fhir.r4b.model.DataType) nextOutput;
-                    if (dt instanceof StringType) {
-                        StringType st = (StringType) dt;
-                        if (st.getValue().equalsIgnoreCase(""))
-                            ParamUtils.add(resultPart, "empty-string");
-                        else
-                            ParamUtils.add(resultPart, dt.fhirType(), st);
-                    } else {
-                        ParamUtils.add(resultPart, dt.fhirType(), dt);
-                    }
+                } else if (nextOutput instanceof org.hl7.fhir.r5.model.DataType) {
+                    var dt = (org.hl7.fhir.r5.model.DataType) nextOutput;
+                    ParamUtils.add(resultPart, dt.fhirType(), dt);
                 }
             }
         }

--- a/src/main/java/com/fhirpathlab/FhirpathTestController.java
+++ b/src/main/java/com/fhirpathlab/FhirpathTestController.java
@@ -477,7 +477,7 @@ public class FhirpathTestController {
         // Parse out the expression tree for the debug output
         var outcome = new org.hl7.fhir.r4b.model.OperationOutcome();
         var pathBasedContextExpression = contextExpression;
-        if (contextExpression != null && contextOutputs.size() > 1) {
+        if (contextExpression != null && contextOutputs.size() > 0) {
             var firstElement = (org.hl7.fhir.r5.elementmodel.Element)contextOutputs.get(0);
             if (firstElement != null)
                 pathBasedContextExpression = firstElement.getPath().replaceAll("\\[[0-9]+\\]", "");

--- a/src/main/java/com/fhirpathlab/FmlTransformController.java
+++ b/src/main/java/com/fhirpathlab/FmlTransformController.java
@@ -120,7 +120,7 @@ public class FmlTransformController {
             }
 
             // Create a new context for the call
-            var context = contextFactory.getContextR5();
+            var context = contextFactory.getContextR4bAsR5();
             var localContext = new org.hl7.fhir.r5.context.SimpleWorkerContext(context);
             readCustomStructureDefinitions(localContext, parameters);
 

--- a/src/main/java/com/fhirpathlab/utils/ParamUtils.java
+++ b/src/main/java/com/fhirpathlab/utils/ParamUtils.java
@@ -60,7 +60,7 @@ public class ParamUtils {
             if (theValue.hasExtension()) {
                 // migrate any extensions to the new type
                 for (var ext : theValue.getExtension()) {
-                    var newExt = new org.hl7.fhir.r4b.model.Extension(ext.getUrl(),  converDataType(ext.getValue()));
+                    var newExt = new org.hl7.fhir.r4b.model.Extension(ext.getUrl(), converDataType(ext.getValue()));
                     ((org.hl7.fhir.r4b.model.PrimitiveType) np).addExtension(newExt);
                 }
             }
@@ -219,8 +219,11 @@ public class ParamUtils {
         result.setValue(dt);
         if (dt instanceof StringType) {
             StringType st = (StringType) dt;
-            if (st.getValue().equalsIgnoreCase(""))
+            if (st.getValue().equalsIgnoreCase("")) {
                 result.setName("empty-string");
+                if (!st.hasExtension())
+                    result.setValue(null);
+            }
         }
     }
 }

--- a/src/main/java/com/fhirpathlab/utils/ParamUtils.java
+++ b/src/main/java/com/fhirpathlab/utils/ParamUtils.java
@@ -212,6 +212,10 @@ public class ParamUtils {
             var stream = new java.io.ByteArrayOutputStream();
             Manager.compose(context, em, stream, Manager.FhirFormat.JSON, OutputStyle.NORMAL, em.fhirType());
 
+            if (em.getPath() != null) {
+                result.addExtension("http://fhir.forms-lab.com/StructureDefinition/resource-path",
+                        new StringType(em.getPath().replace("[x]", "")));
+            }
             if (em.isResource()) {
                 // if this is an R4 resource, we can put it into the object model
                 if (em.getProperty().getStructure().getFhirVersion().toCode().charAt(0) == '4') {
@@ -278,6 +282,10 @@ public class ParamUtils {
             @SuppressWarnings("deprecation") org.hl7.fhir.r4b.elementmodel.Element em) {
         var result = theParameter.addPart();
         result.setName(em.fhirType());
+        if (em.getPath() != null) {
+            result.addExtension("http://fhir.forms-lab.com/StructureDefinition/resource-path",
+                    new StringType(em.getPath().replace("[x]", "")));
+        }
 
         try {
             if (em.isResource()) {

--- a/src/main/java/com/fhirpathlab/utils/ParamUtils.java
+++ b/src/main/java/com/fhirpathlab/utils/ParamUtils.java
@@ -1,12 +1,21 @@
 package com.fhirpathlab.utils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 
-import org.hl7.fhir.r4b.context.IWorkerContext;
-import org.hl7.fhir.r4b.elementmodel.Manager;
-import org.hl7.fhir.r4b.formats.IParser.OutputStyle;
+import org.hl7.fhir.r5.context.IWorkerContext;
+import org.hl7.fhir.r5.model.DataType;
+import org.hl7.fhir.utilities.graphql.Parser;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.elementmodel.ValidatedFragment;
+import org.hl7.fhir.r5.formats.IParser.OutputStyle;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.exceptions.FHIRFormatError;
 import org.hl7.fhir.r4b.model.Parameters;
 import org.hl7.fhir.r4b.model.StringType;
+import org.hl7.fhir.r4b.model.Enumerations.FHIRVersion;
 import org.hl7.fhir.r4b.model.Parameters.ParametersParameterComponent;
 
 public class ParamUtils {
@@ -25,6 +34,137 @@ public class ParamUtils {
         var result = theParameter.addPart();
         result.setName(theName);
         result.setValue(theValue);
+        return result;
+    }
+
+    public static ParametersParameterComponent add(ParametersParameterComponent theParameter, String theName,
+            DataType theValue) {
+        var result = theParameter.addPart();
+        result.setName(theName);
+        if (theValue instanceof org.hl7.fhir.r5.model.StringType) {
+            org.hl7.fhir.r5.model.StringType st = (org.hl7.fhir.r5.model.StringType) theValue;
+            if (st.getValue().equalsIgnoreCase("")) {
+                result.setName("empty-string");
+                // result.setValue(new StringType("empty-string"));
+            } else {
+                var valWithExt = new StringType(st.getValue());
+                result.setValue(valWithExt);
+                // what about any extensions?
+            }
+        } else {
+            // and need to convert the DataType to the correct type
+            // ByteArrayOutputStream bs = new ByteArrayOutputStream();
+            // org.hl7.fhir.r5.formats.JsonParser jp5 = new
+            // org.hl7.fhir.r5.formats.JsonParser();
+            // org.hl7.fhir.r4b.formats.JsonParser jp4 = new
+            // org.hl7.fhir.r4b.formats.JsonParser();
+            // try {
+            // jp5.compose(bs, theValue, "root");
+            // ByteArrayInputStream bi = new ByteArrayInputStream(bs.toByteArray());
+            // var dt4 = jp4.parseType(bi, theValue.fhirType());
+            // ParamUtils.add(result, theValue.fhirType(), dt4);
+            // } catch (IOException e) {
+            // }
+            result.setValue(converDataType(theValue));
+            // ParamUtils.add(result, theValue.fhirType(), converDataType(theValue));
+        }
+
+        // what about any extensions?
+        if (theValue.hasExtension()) {
+
+        }
+        return result;
+    }
+
+    public static org.hl7.fhir.r4b.model.DataType converDataType(org.hl7.fhir.r5.model.DataType theValue) {
+        org.hl7.fhir.r4b.model.DataType result = null;
+        org.hl7.fhir.r5.formats.JsonParser jp5 = new org.hl7.fhir.r5.formats.JsonParser();
+        org.hl7.fhir.r4b.formats.JsonParser jp4 = new org.hl7.fhir.r4b.formats.JsonParser();
+
+        if (theValue.isPrimitive()) {
+
+        }
+        if (theValue instanceof org.hl7.fhir.r5.model.StringType) {
+            org.hl7.fhir.r5.model.StringType st = (org.hl7.fhir.r5.model.StringType) theValue;
+            if (st.getValue().equalsIgnoreCase("")) {
+                result = new StringType("empty-string");
+            } else {
+                if (theValue instanceof org.hl7.fhir.r5.model.CodeType)
+                    result = new org.hl7.fhir.r4b.model.CodeType(st.getValue());
+                else if (theValue instanceof org.hl7.fhir.r5.model.MarkdownType)
+                    result = new org.hl7.fhir.r4b.model.MarkdownType(st.getValue());
+                else
+                    result = new StringType(st.getValue());
+            }
+        } else if (theValue instanceof org.hl7.fhir.r5.model.UriType) {
+            org.hl7.fhir.r5.model.UriType st = (org.hl7.fhir.r5.model.UriType) theValue;
+            if (st.getValue().equalsIgnoreCase("")) {
+                result = new StringType("empty-string");
+            } else {
+                if (theValue instanceof org.hl7.fhir.r5.model.CanonicalType)
+                    result = new org.hl7.fhir.r4b.model.CanonicalType(st.getValue());
+
+                else if (theValue instanceof org.hl7.fhir.r5.model.IdType)
+                    result = new org.hl7.fhir.r4b.model.IdType(st.getValue());
+
+                else if (theValue instanceof org.hl7.fhir.r5.model.OidType)
+                    result = new org.hl7.fhir.r4b.model.OidType(st.getValue());
+
+                else if (theValue instanceof org.hl7.fhir.r5.model.SidType) {
+                    var newSid = new org.hl7.fhir.r4b.model.SidType();
+                    newSid.fromStringValue(st.getValue());
+                    result = newSid;
+                }
+
+                else if (theValue instanceof org.hl7.fhir.r5.model.UrlType)
+                    result = new org.hl7.fhir.r4b.model.UrlType(st.getValue());
+
+                else if (theValue instanceof org.hl7.fhir.r5.model.UuidType)
+                    result = new org.hl7.fhir.r4b.model.UuidType(st.getValue());
+
+                else
+                    result = new org.hl7.fhir.r4b.model.UriType(st.getValue());
+            }
+        } else if (theValue instanceof org.hl7.fhir.r5.model.IntegerType) {
+            org.hl7.fhir.r5.model.IntegerType st = (org.hl7.fhir.r5.model.IntegerType) theValue;
+            result = new org.hl7.fhir.r4b.model.IntegerType(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.DecimalType) {
+            org.hl7.fhir.r5.model.DecimalType st = (org.hl7.fhir.r5.model.DecimalType) theValue;
+            result = new org.hl7.fhir.r4b.model.DecimalType(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.Integer64Type) {
+            org.hl7.fhir.r5.model.Integer64Type st = (org.hl7.fhir.r5.model.Integer64Type) theValue;
+            result = new org.hl7.fhir.r4b.model.Integer64Type(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.BooleanType) {
+            org.hl7.fhir.r5.model.BooleanType st = (org.hl7.fhir.r5.model.BooleanType) theValue;
+            result = new org.hl7.fhir.r4b.model.BooleanType(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.Base64BinaryType) {
+            org.hl7.fhir.r5.model.Base64BinaryType st = (org.hl7.fhir.r5.model.Base64BinaryType) theValue;
+            result = new org.hl7.fhir.r4b.model.Base64BinaryType(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.DateType) {
+            org.hl7.fhir.r5.model.DateType st = (org.hl7.fhir.r5.model.DateType) theValue;
+            result = new org.hl7.fhir.r4b.model.DateType(st.getValue(), st.getPrecision());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.DateTimeType) {
+            org.hl7.fhir.r5.model.DateTimeType st = (org.hl7.fhir.r5.model.DateTimeType) theValue;
+            result = new org.hl7.fhir.r4b.model.DateTimeType(st.getValue(), st.getPrecision());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.InstantType) {
+            org.hl7.fhir.r5.model.InstantType st = (org.hl7.fhir.r5.model.InstantType) theValue;
+            result = new org.hl7.fhir.r4b.model.InstantType(st.getValue());
+        } else if (theValue instanceof org.hl7.fhir.r5.model.TimeType) {
+            org.hl7.fhir.r5.model.TimeType st = (org.hl7.fhir.r5.model.TimeType) theValue;
+            result = new org.hl7.fhir.r4b.model.TimeType(st.getValue());
+        } else {
+
+            // I think we just have enumeration and Xhtml as the left over types...
+
+            // and need to convert the DataType to the correct type
+            ByteArrayOutputStream bs = new ByteArrayOutputStream();
+            try {
+                jp5.compose(bs, theValue, "root");
+                ByteArrayInputStream bi = new ByteArrayInputStream(bs.toByteArray());
+                result = jp4.parseType(bi, theValue.fhirType());
+            } catch (IOException e) {
+            }
+        }
         return result;
     }
 
@@ -59,10 +199,83 @@ public class ParamUtils {
         return result;
     }
 
+    @SuppressWarnings("deprecation")
     public static ParametersParameterComponent addTypedElement(IWorkerContext context,
-            org.hl7.fhir.r4b.elementmodel.ObjectConverter oc,
+            org.hl7.fhir.r5.elementmodel.ObjectConverter oc,
             Parameters.ParametersParameterComponent theParameter,
-            org.hl7.fhir.r4b.elementmodel.Element em) {
+            org.hl7.fhir.r5.elementmodel.Element em) {
+        var result = theParameter.addPart();
+        result.setName(em.fhirType());
+
+        try {
+            var jsonParser = new org.hl7.fhir.r4b.formats.JsonParser();
+            var stream = new java.io.ByteArrayOutputStream();
+            Manager.compose(context, em, stream, Manager.FhirFormat.JSON, OutputStyle.NORMAL, em.fhirType());
+
+            if (em.isResource()) {
+                // if this is an R4 resource, we can put it into the object model
+                if (em.getProperty().getStructure().getFhirVersion().toCode().charAt(0) == '4') {
+                    var resource = jsonParser.parse(stream.toString());
+                    result.setResource(resource);
+                } else {
+                    result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
+                            new StringType(stream.toString()));
+                }
+
+            } else if (em.fhirType().equalsIgnoreCase("BackboneElement")) {
+                String backboneJson = stream.toString().replace("\"resourceType\":\"BackboneElement\",", "");
+                result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
+                        new StringType(backboneJson));
+
+            } else if (em.fhirType().equalsIgnoreCase("Extension")) {
+                String extensionJson = stream.toString().replace("\"resourceType\":\"Extension\",", "");
+                result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
+                        new StringType(extensionJson));
+
+            } else if (em.isPrimitive()) {
+                var dt = oc.convertToType(em);
+                var r4dt = converDataType(dt);
+                result.setValue(r4dt);
+                // if (dt instanceof org.hl7.fhir.r5.model.StringType) {
+                // org.hl7.fhir.r5.model.StringType st = (org.hl7.fhir.r5.model.StringType) dt;
+                // if (st.getValue().equalsIgnoreCase(""))
+                // result.setName("empty-string");
+                // else {
+                // var valWithExt = new StringType(st.getValue());
+                // result.setValue(valWithExt);
+                // // what about any extensions?
+                // }
+                // } else {
+                // // and need to convert the DataType to the correct type
+                // var val = jsonParser.parseAnyType(stream.toString(), dt.fhirType());
+                // result.setValue(val);
+                // }
+
+            } else {
+                // Let over are the bigger DataTypes such as Identifier/HumanName/Period etc.
+                try {
+                    var val = jsonParser.parseAnyType(stream.toString(), em.fhirType());
+                    result.setValue(val);
+                } catch (FHIRFormatError ex) {
+                    result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
+                            new StringType(stream.toString()));
+                }
+            }
+
+        } catch (IOException e) {
+            ParamUtils.add(result, "cast-error", new StringType(e.getMessage()));
+        } catch (java.lang.IllegalArgumentException e) {
+            ParamUtils.add(result, "cast-error", new StringType(e.getMessage()));
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static ParametersParameterComponent addTypedElement(IWorkerContext context,
+            @SuppressWarnings("deprecation") org.hl7.fhir.r4b.elementmodel.ObjectConverter oc,
+            Parameters.ParametersParameterComponent theParameter,
+            @SuppressWarnings("deprecation") org.hl7.fhir.r4b.elementmodel.Element em) {
         var result = theParameter.addPart();
         result.setName(em.fhirType());
 
@@ -72,19 +285,22 @@ public class ParamUtils {
 
             } else if (em.fhirType().equalsIgnoreCase("BackboneElement")) {
                 var stream = new java.io.ByteArrayOutputStream();
-                Manager.compose(context, em, stream, Manager.FhirFormat.JSON, OutputStyle.NORMAL, em.fhirType());
+                // Manager.compose(context, em, stream, Manager.FhirFormat.JSON,
+                // OutputStyle.NORMAL, em.fhirType());
                 String backboneJson = stream.toString().replace("\"resourceType\":\"BackboneElement\",", "");
                 result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
                         new StringType(backboneJson));
 
             } else if (em.fhirType().equalsIgnoreCase("Extension")) {
                 var stream = new java.io.ByteArrayOutputStream();
-                Manager.compose(context, em, stream, Manager.FhirFormat.JSON, OutputStyle.NORMAL, em.fhirType());
+                // Manager.compose(context, em, stream, Manager.FhirFormat.JSON,
+                // OutputStyle.NORMAL, em.fhirType());
                 String extensionJson = stream.toString().replace("\"resourceType\":\"Extension\",", "");
                 result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
                         new StringType(extensionJson));
 
             } else if (em.isPrimitive()) {
+                @SuppressWarnings("deprecation")
                 var dt = oc.convertToType(em);
                 if (dt instanceof StringType) {
                     StringType st = (StringType) dt;
@@ -98,12 +314,13 @@ public class ParamUtils {
 
             } else {
                 // Let over are the bigger DataTypes such as Identifier/HumanName/Period etc.
+                @SuppressWarnings("deprecation")
                 var dt = em.asType();
                 result.setValue(dt);
             }
 
-        } catch (IOException e) {
-            ParamUtils.add(result, "cast-error", new StringType(e.getMessage()));
+            // } catch (IOException e) {
+            // ParamUtils.add(result, "cast-error", new StringType(e.getMessage()));
         } catch (java.lang.IllegalArgumentException e) {
             ParamUtils.add(result, "cast-error", new StringType(e.getMessage()));
         }

--- a/src/main/java/com/fhirpathlab/utils/ParamUtils.java
+++ b/src/main/java/com/fhirpathlab/utils/ParamUtils.java
@@ -160,6 +160,7 @@ public class ParamUtils {
                     result.setValue(val); // throw's if the type isn't a valid params type, in which case go the json
                                           // thing...
                 } catch (Error ex) {
+                    jsonText = jsonText.replace("\"resourceType\":\"" + em.fhirType() + "\",", "");
                     result.addExtension("http://fhir.forms-lab.com/StructureDefinition/json-value",
                             new StringType(jsonText));
                 }

--- a/src/main/java/com/fhirpathlab/utils/SimplifiedExpressionNode.java
+++ b/src/main/java/com/fhirpathlab/utils/SimplifiedExpressionNode.java
@@ -103,8 +103,10 @@ public class SimplifiedExpressionNode implements ISimplifiedExpressionNode {
             return null;
         SimplifiedExpressionNode jsonNode = new SimplifiedExpressionNode();
         // jsonNode.uniqueId = node.getUniqueId();
-        jsonNode.startLine = node.getStart().getLine();
-        jsonNode.startColumn = node.getStart().getColumn();
+        if (node.getStart() != null) {
+            jsonNode.startLine = node.getStart().getLine();
+            jsonNode.startColumn = node.getStart().getColumn();
+        }
         if (node.getOpStart() != null) {
             jsonNode.startOpLine = node.getOpStart().getLine();
             jsonNode.startOpColumn = node.getOpStart().getColumn();
@@ -173,8 +175,10 @@ public class SimplifiedExpressionNode implements ISimplifiedExpressionNode {
             return null;
         SimplifiedExpressionNode jsonNode = new SimplifiedExpressionNode();
         // jsonNode.uniqueId = node.getUniqueId();
-        jsonNode.startLine = node.getStart().getLine();
-        jsonNode.startColumn = node.getStart().getColumn();
+        if (node.getStart() != null) {
+            jsonNode.startLine = node.getStart().getLine();
+            jsonNode.startColumn = node.getStart().getColumn();
+        }
         if (node.getOpStart() != null) {
             jsonNode.startOpLine = node.getOpStart().getLine();
             jsonNode.startOpColumn = node.getOpStart().getColumn();

--- a/src/test/data/simple.response.json
+++ b/src/test/data/simple.response.json
@@ -5,7 +5,7 @@
     "name" : "parameters",
     "part" : [{
       "name" : "evaluator",
-      "valueString" : "Java 6.5.19 (r4b)"
+      "valueString" : "Java 6.5.19 (R4B)"
     },
     {
       "name" : "context",
@@ -17,20 +17,24 @@
     },
     {
       "name" : "parseDebugTree",
-      "valueString" : "{\n  \"ExpressionType\" : \"FunctionCallExpression\",\n  \"Name\" : \"join\",\n  \"Arguments\" : [ {\n    \"ExpressionType\" : \"FunctionCallExpression\",\n    \"Name\" : \"combine\",\n    \"Arguments\" : [ {\n      \"ExpressionType\" : \"FunctionCallExpression\",\n      \"Name\" : \"join\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"ChildExpression\",\n        \"Name\" : \"given\",\n        \"Arguments\" : [ {\n          \"ExpressionType\" : \"FunctionCallExpression\",\n          \"Name\" : \"trace\",\n          \"Arguments\" : [ {\n            \"ExpressionType\" : \"AxisExpression\",\n            \"Name\" : \"builtin.that\",\n            \"ReturnType\" : \"Patient.name\"\n          }, {\n            \"ExpressionType\" : \"ConstantExpression\",\n            \"Name\" : \"trc\",\n            \"ReturnType\" : \"string\",\n            \"Line\" : 1,\n            \"Column\" : 12\n          } ],\n          \"ReturnType\" : \"HumanName\",\n          \"Line\" : 1,\n          \"Column\" : 6\n        } ],\n        \"ReturnType\" : \"string\",\n        \"Line\" : 1,\n        \"Column\" : 19\n      }, {\n        \"ExpressionType\" : \"ConstantExpression\",\n        \"Name\" : \" \",\n        \"ReturnType\" : \"string\",\n        \"Line\" : 1,\n        \"Column\" : 28\n      } ],\n      \"ReturnType\" : \"string\",\n      \"Line\" : 1,\n      \"Column\" : 24\n    }, {\n      \"ExpressionType\" : \"ChildExpression\",\n      \"Name\" : \"family\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"AxisExpression\",\n        \"Name\" : \"builtin.that\",\n        \"ReturnType\" : \"string\"\n      } ],\n      \"ReturnType\" : \"string\",\n      \"Line\" : 2,\n      \"Column\" : 17\n    } ],\n    \"ReturnType\" : \"string[]\",\n    \"Line\" : 2,\n    \"Column\" : 10\n  }, {\n    \"ExpressionType\" : \"ConstantExpression\",\n    \"Name\" : \", \",\n    \"ReturnType\" : \"string\",\n    \"Line\" : 2,\n    \"Column\" : 28\n  } ],\n  \"ReturnType\" : \"string\",\n  \"Line\" : 2,\n  \"Column\" : 23\n}"
+      "valueString" : "{\n  \"ExpressionType\" : \"FunctionCallExpression\",\n  \"Name\" : \"join\",\n  \"Arguments\" : [ {\n    \"ExpressionType\" : \"FunctionCallExpression\",\n    \"Name\" : \"combine\",\n    \"Arguments\" : [ {\n      \"ExpressionType\" : \"FunctionCallExpression\",\n      \"Name\" : \"join\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"ChildExpression\",\n        \"Name\" : \"given\",\n        \"Arguments\" : [ {\n          \"ExpressionType\" : \"FunctionCallExpression\",\n          \"Name\" : \"trace\",\n          \"Arguments\" : [ {\n            \"ExpressionType\" : \"AxisExpression\",\n            \"Name\" : \"builtin.that\",\n            \"ReturnType\" : \"Patient.name\"\n          }, {\n            \"ExpressionType\" : \"ConstantExpression\",\n            \"Name\" : \"trc\",\n            \"ReturnType\" : \"system.String\",\n            \"Line\" : 1,\n            \"Column\" : 7\n          } ],\n          \"ReturnType\" : \"HumanName\",\n          \"Line\" : 1,\n          \"Column\" : 1\n        } ],\n        \"ReturnType\" : \"string[]\",\n        \"Line\" : 1,\n        \"Column\" : 14\n      }, {\n        \"ExpressionType\" : \"ConstantExpression\",\n        \"Name\" : \" \",\n        \"ReturnType\" : \"system.String\",\n        \"Line\" : 1,\n        \"Column\" : 25\n      } ],\n      \"ReturnType\" : \"system.String\",\n      \"Line\" : 1,\n      \"Column\" : 20\n    }, {\n      \"ExpressionType\" : \"ChildExpression\",\n      \"Name\" : \"family\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"AxisExpression\",\n        \"Name\" : \"builtin.that\",\n        \"ReturnType\" : \"system.String\"\n      } ],\n      \"ReturnType\" : \"string\",\n      \"Line\" : 2,\n      \"Column\" : 11\n    } ],\n    \"ReturnType\" : \"string[], system.String[]\",\n    \"Line\" : 2,\n    \"Column\" : 3\n  }, {\n    \"ExpressionType\" : \"ConstantExpression\",\n    \"Name\" : \", \",\n    \"ReturnType\" : \"system.String\",\n    \"Line\" : 2,\n    \"Column\" : 24\n  } ],\n  \"ReturnType\" : \"system.String\",\n  \"Line\" : 2,\n  \"Column\" : 19\n}"
     },
     {
       "name" : "parseDebugTreeJava",
-      "valueString" : "{\n  \"Kind\" : \"Function\",\n  \"Function\" : \"trace\",\n  \"Parameters\" : [ {\n    \"Kind\" : \"Constant\",\n    \"Constant\" : \"trc\",\n    \"IsProximal\" : true,\n    \"Types\" : \"string\",\n    \"StartLine\" : 1,\n    \"StartColumn\" : 12\n  } ],\n  \"Inner\" : {\n    \"Kind\" : \"Name\",\n    \"Name\" : \"given\",\n    \"Inner\" : {\n      \"Kind\" : \"Function\",\n      \"Function\" : \"join\",\n      \"Parameters\" : [ {\n        \"Kind\" : \"Constant\",\n        \"Constant\" : \" \",\n        \"IsProximal\" : true,\n        \"Types\" : \"string\",\n        \"StartLine\" : 1,\n        \"StartColumn\" : 28\n      } ],\n      \"Inner\" : {\n        \"Kind\" : \"Function\",\n        \"Function\" : \"combine\",\n        \"Parameters\" : [ {\n          \"Kind\" : \"Name\",\n          \"Name\" : \"family\",\n          \"IsProximal\" : true,\n          \"Types\" : \"string\",\n          \"StartLine\" : 2,\n          \"StartColumn\" : 17\n        } ],\n        \"Inner\" : {\n          \"Kind\" : \"Function\",\n          \"Function\" : \"join\",\n          \"Parameters\" : [ {\n            \"Kind\" : \"Constant\",\n            \"Constant\" : \", \",\n            \"IsProximal\" : true,\n            \"Types\" : \"string\",\n            \"StartLine\" : 2,\n            \"StartColumn\" : 28\n          } ],\n          \"IsProximal\" : false,\n          \"Types\" : \"string\",\n          \"StartLine\" : 2,\n          \"StartColumn\" : 23\n        },\n        \"IsProximal\" : false,\n        \"Types\" : \"string[]\",\n        \"StartLine\" : 2,\n        \"StartColumn\" : 10\n      },\n      \"IsProximal\" : false,\n      \"Types\" : \"string\",\n      \"StartLine\" : 1,\n      \"StartColumn\" : 24\n    },\n    \"IsProximal\" : false,\n    \"Types\" : \"string\",\n    \"StartLine\" : 1,\n    \"StartColumn\" : 19\n  },\n  \"IsProximal\" : true,\n  \"Types\" : \"HumanName\",\n  \"StartLine\" : 1,\n  \"StartColumn\" : 6\n}"
+      "valueString" : "{\n  \"Kind\" : \"Function\",\n  \"Function\" : \"trace\",\n  \"Parameters\" : [ {\n    \"Kind\" : \"Constant\",\n    \"Constant\" : \"trc\",\n    \"IsProximal\" : true,\n    \"Types\" : \"system.String\",\n    \"StartLine\" : 1,\n    \"StartColumn\" : 7\n  } ],\n  \"Inner\" : {\n    \"Kind\" : \"Name\",\n    \"Name\" : \"given\",\n    \"Inner\" : {\n      \"Kind\" : \"Function\",\n      \"Function\" : \"join\",\n      \"Parameters\" : [ {\n        \"Kind\" : \"Constant\",\n        \"Constant\" : \" \",\n        \"IsProximal\" : true,\n        \"Types\" : \"system.String\",\n        \"StartLine\" : 1,\n        \"StartColumn\" : 25\n      } ],\n      \"Inner\" : {\n        \"Kind\" : \"Function\",\n        \"Function\" : \"combine\",\n        \"Parameters\" : [ {\n          \"Kind\" : \"Name\",\n          \"Name\" : \"family\",\n          \"IsProximal\" : true,\n          \"Types\" : \"string\",\n          \"StartLine\" : 2,\n          \"StartColumn\" : 11\n        } ],\n        \"Inner\" : {\n          \"Kind\" : \"Function\",\n          \"Function\" : \"join\",\n          \"Parameters\" : [ {\n            \"Kind\" : \"Constant\",\n            \"Constant\" : \", \",\n            \"IsProximal\" : true,\n            \"Types\" : \"system.String\",\n            \"StartLine\" : 2,\n            \"StartColumn\" : 24\n          } ],\n          \"IsProximal\" : false,\n          \"Types\" : \"system.String\",\n          \"StartLine\" : 2,\n          \"StartColumn\" : 19\n        },\n        \"IsProximal\" : false,\n        \"Types\" : \"string[], system.String[]\",\n        \"StartLine\" : 2,\n        \"StartColumn\" : 3\n      },\n      \"IsProximal\" : false,\n      \"Types\" : \"system.String\",\n      \"StartLine\" : 1,\n      \"StartColumn\" : 20\n    },\n    \"IsProximal\" : false,\n    \"Types\" : \"string[]\",\n    \"StartLine\" : 1,\n    \"StartColumn\" : 14\n  },\n  \"IsProximal\" : true,\n  \"Types\" : \"HumanName\",\n  \"StartLine\" : 1,\n  \"StartColumn\" : 1\n}"
     }]
   },
   {
     "name" : "result",
-    "valueString" : "name[0]",
+    "valueString" : "Patient.name[0]",
     "part" : [{
       "name" : "trace",
       "valueString" : "trc",
       "part" : [{
+        "extension" : [{
+          "url" : "http://fhir.forms-lab.com/StructureDefinition/resource-path",
+          "valueString" : "Patient.name[0]"
+        }],
         "name" : "HumanName",
         "valueHumanName" : {
           "use" : "official",
@@ -47,11 +51,15 @@
   },
   {
     "name" : "result",
-    "valueString" : "name[1]",
+    "valueString" : "Patient.name[1]",
     "part" : [{
       "name" : "trace",
       "valueString" : "trc",
       "part" : [{
+        "extension" : [{
+          "url" : "http://fhir.forms-lab.com/StructureDefinition/resource-path",
+          "valueString" : "Patient.name[1]"
+        }],
         "name" : "HumanName",
         "valueHumanName" : {
           "use" : "usual",
@@ -66,11 +74,15 @@
   },
   {
     "name" : "result",
-    "valueString" : "name[2]",
+    "valueString" : "Patient.name[2]",
     "part" : [{
       "name" : "trace",
       "valueString" : "trc",
       "part" : [{
+        "extension" : [{
+          "url" : "http://fhir.forms-lab.com/StructureDefinition/resource-path",
+          "valueString" : "Patient.name[2]"
+        }],
         "name" : "HumanName",
         "valueHumanName" : {
           "use" : "maiden",

--- a/src/test/data/simple.response.json
+++ b/src/test/data/simple.response.json
@@ -16,6 +16,136 @@
       "valueString" : "trace('trc').given.join(' ')\n.combine(family).join(', ')"
     },
     {
+      "name" : "resource",
+      "resource" : {
+        "resourceType" : "Patient",
+        "id" : "example",
+        "identifier" : [{
+          "use" : "usual",
+          "type" : {
+            "coding" : [{
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code" : "MR"
+            }]
+          },
+          "system" : "urn:oid:1.2.36.146.595.217.0.1",
+          "value" : "12345",
+          "period" : {
+            "start" : "2001-05-06"
+          },
+          "assigner" : {
+            "display" : "Acme Healthcare"
+          }
+        }],
+        "active" : true,
+        "name" : [{
+          "use" : "official",
+          "family" : "Chalmers",
+          "given" : ["Peter",
+          "James"]
+        },
+        {
+          "use" : "usual",
+          "given" : ["Jim"]
+        },
+        {
+          "use" : "maiden",
+          "family" : "Windsor",
+          "given" : ["Peter",
+          "James"],
+          "period" : {
+            "end" : "2002"
+          }
+        }],
+        "telecom" : [{
+          "use" : "home"
+        },
+        {
+          "system" : "phone",
+          "value" : "(03) 5555 6473",
+          "use" : "work",
+          "rank" : 1
+        },
+        {
+          "system" : "phone",
+          "value" : "(03) 3410 5613",
+          "use" : "mobile",
+          "rank" : 2
+        },
+        {
+          "system" : "phone",
+          "value" : "(03) 5555 8834",
+          "use" : "old",
+          "period" : {
+            "end" : "2014"
+          }
+        }],
+        "gender" : "male",
+        "birthDate" : "1974-12-25",
+        "_birthDate" : {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+            "valueDateTime" : "1974-12-25T14:35:45-05:00"
+          }]
+        },
+        "deceasedBoolean" : false,
+        "address" : [{
+          "use" : "home",
+          "type" : "both",
+          "text" : "534 Erewhon St PeasantVille, Rainbow, Vic  3999",
+          "line" : ["534 Erewhon St"],
+          "city" : "PleasantVille",
+          "district" : "Rainbow",
+          "state" : "Vic",
+          "postalCode" : "3999",
+          "period" : {
+            "start" : "1974-12-25"
+          }
+        }],
+        "contact" : [{
+          "relationship" : [{
+            "coding" : [{
+              "system" : "http://terminology.hl7.org/CodeSystem/v2-0131",
+              "code" : "N"
+            }]
+          }],
+          "name" : {
+            "family" : "du Marché",
+            "_family" : {
+              "extension" : [{
+                "url" : "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                "valueString" : "VV"
+              }]
+            },
+            "given" : ["Bénédicte"]
+          },
+          "telecom" : [{
+            "system" : "phone",
+            "value" : "+33 (237) 998327"
+          }],
+          "address" : {
+            "use" : "home",
+            "type" : "both",
+            "line" : ["534 Erewhon St"],
+            "city" : "PleasantVille",
+            "district" : "Rainbow",
+            "state" : "Vic",
+            "postalCode" : "3999",
+            "period" : {
+              "start" : "1974-12-25"
+            }
+          },
+          "gender" : "female",
+          "period" : {
+            "start" : "2012"
+          }
+        }],
+        "managingOrganization" : {
+          "reference" : "Organization/1"
+        }
+      }
+    },
+    {
       "name" : "parseDebugTree",
       "valueString" : "{\n  \"ExpressionType\" : \"FunctionCallExpression\",\n  \"Name\" : \"join\",\n  \"Arguments\" : [ {\n    \"ExpressionType\" : \"FunctionCallExpression\",\n    \"Name\" : \"combine\",\n    \"Arguments\" : [ {\n      \"ExpressionType\" : \"FunctionCallExpression\",\n      \"Name\" : \"join\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"ChildExpression\",\n        \"Name\" : \"given\",\n        \"Arguments\" : [ {\n          \"ExpressionType\" : \"FunctionCallExpression\",\n          \"Name\" : \"trace\",\n          \"Arguments\" : [ {\n            \"ExpressionType\" : \"AxisExpression\",\n            \"Name\" : \"builtin.that\",\n            \"ReturnType\" : \"Patient.name\"\n          }, {\n            \"ExpressionType\" : \"ConstantExpression\",\n            \"Name\" : \"trc\",\n            \"ReturnType\" : \"system.String\",\n            \"Line\" : 1,\n            \"Column\" : 7\n          } ],\n          \"ReturnType\" : \"HumanName\",\n          \"Line\" : 1,\n          \"Column\" : 1\n        } ],\n        \"ReturnType\" : \"string[]\",\n        \"Line\" : 1,\n        \"Column\" : 14\n      }, {\n        \"ExpressionType\" : \"ConstantExpression\",\n        \"Name\" : \" \",\n        \"ReturnType\" : \"system.String\",\n        \"Line\" : 1,\n        \"Column\" : 25\n      } ],\n      \"ReturnType\" : \"system.String\",\n      \"Line\" : 1,\n      \"Column\" : 20\n    }, {\n      \"ExpressionType\" : \"ChildExpression\",\n      \"Name\" : \"family\",\n      \"Arguments\" : [ {\n        \"ExpressionType\" : \"AxisExpression\",\n        \"Name\" : \"builtin.that\",\n        \"ReturnType\" : \"system.String\"\n      } ],\n      \"ReturnType\" : \"string\",\n      \"Line\" : 2,\n      \"Column\" : 11\n    } ],\n    \"ReturnType\" : \"string[], system.String[]\",\n    \"Line\" : 2,\n    \"Column\" : 3\n  }, {\n    \"ExpressionType\" : \"ConstantExpression\",\n    \"Name\" : \", \",\n    \"ReturnType\" : \"system.String\",\n    \"Line\" : 2,\n    \"Column\" : 24\n  } ],\n  \"ReturnType\" : \"system.String\",\n  \"Line\" : 2,\n  \"Column\" : 19\n}"
     },


### PR DESCRIPTION
* Fix a few bugs
* Include the path if known in the element model of the results
* include the parsed resource in the output (helps with debugging)
* Uses the R5 Element Model/FhirPath engine rather than the version specific object model/engine